### PR TITLE
Make android.db creation to fail on error

### DIFF
--- a/data/db/android/Makefile.am
+++ b/data/db/android/Makefile.am
@@ -40,6 +40,7 @@ endif
 android.db: $(android_raw_data) $(create_scripts)
 	$(AM_V_GEN) \
 	$(RM) $@; \
+	set -o pipefail; \
 	$(srcdir)/create_db.py $(srcdir)/rawdict_utf16_65105_freq.txt | @SQLITE3@ $@ || \
 		( $(RM) $@ ; exit 1 )
 


### PR DESCRIPTION
An error raised in create_db.py currently fails silently and generates a broken database without blocking the build. Let's set -o pipefail to make it an error.