### PR TITLE
Revert "Fix m_preedit_text.selected_text"

### DIFF
--- a/src/PinyinContext.cc
+++ b/src/PinyinContext.cc
@@ -149,7 +149,7 @@ PinyinContext::updatePreeditText ()
         }
     }
 
-    m_preedit_text.selected_text = m_buffer.substr (edit_begin_byte);
+    m_preedit_text.selected_text = m_buffer.substr (0, edit_begin_byte);
     m_preedit_text.candidate_text = m_buffer.substr (edit_begin_byte, edit_end_byte - edit_begin_byte);
     m_preedit_text.rest_text = m_buffer.substr (edit_end_byte);
 


### PR DESCRIPTION
This reverts commit 0949bb294c29a2790554884093d82ff40ed40759.

The intention of `selected_text` apparently was to hold the beginning of the buffer, up to `edit_begin_byte`. With the rest of the buffer split between `candidate_text` and `rest_text`.

This is also what is currently done in
`BopomofoContext::updatePreeditText()` as well.

/cc @TTimo